### PR TITLE
Google Maps Routes API fixes

### DIFF
--- a/packages/google_maps_routes_api/README.md
+++ b/packages/google_maps_routes_api/README.md
@@ -32,7 +32,7 @@ You can then use the routesService object to make requests to the Google Routes 
 <?code-excerpt "readme_excerpts.dart (SampleUsage)"?>
 ```dart
 
-import 'package:google_maps_routes_api/routes_service.dart';
+import 'package:google_maps_routes_api/google_maps_routes_api.dart';
 
 final RoutesService routesService = RoutesService(apiKey: 'GOOGLE_API_KEY');
 

--- a/packages/google_maps_routes_api/pubspec.yaml
+++ b/packages/google_maps_routes_api/pubspec.yaml
@@ -9,4 +9,6 @@ environment:
 
 dependencies:
   http: ^0.13.5
-  test: any
+  
+dev_dependencies:
+  test: ^1.22.0


### PR DESCRIPTION
* Move `test` dependecy to dev-dependencies. This was causing one of the CI runners to fail.
* Updated excerpts.
